### PR TITLE
Improve room designer UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,14 +12,17 @@
   <div id="ui">
     <button id="add-bed">Добавить кровать</button>
     <button id="add-table">Добавить стол</button>
-    <input id="seed-input" placeholder="Вставьте сид или нажмите «Сгенерировать»"/>
+    <button id="rotate-item">Повернуть выбранный</button>
+    <input id="seed-input" placeholder="Вставьте сид или нажмите «Сгенерировать" />
     <button id="load-seed">Загрузить сид</button>
     <button id="generate-seed">Сгенерировать сид</button>
-    <textarea id="seed-output" readonly rows="3"></textarea>
+    <button id="copy-seed">Копировать сид</button>
+    <textarea id="seed-output" readonly rows="2"></textarea>
   </div>
 
   <!-- PixiJS с CDN -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/7.2.0/pixi.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/lz-string/1.4.4/lz-string.min.js"></script>
   <script src="main.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,1 +1,45 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
 
+#game-container {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #d0d0d0;
+}
+
+canvas {
+  max-width: 100%;
+  height: auto;
+}
+
+#ui {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 8px;
+  background: #fafafa;
+  box-shadow: 0 -2px 4px rgba(0,0,0,0.1);
+}
+
+#ui button,
+#ui input,
+#ui textarea {
+  font-size: 1rem;
+}
+
+#seed-output {
+  flex: 1 1 100%;
+}
+
+@media (min-width: 600px) {
+  #ui {
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
## Summary
- make layout mobile-friendly
- draw simple walls and add drag+rotate for furniture
- compress seeds with LZString
- add copy seed button

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_6859d368c7048332a1a3b58fe948e170