### PR TITLE
Add comparison feature and color controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,17 +7,39 @@
   <title>Room Designer</title>
 </head>
 <body>
-  <div id="game-container"></div>
+  <div id="game-container">
+    <div id="room1" class="room"></div>
+    <div id="room2" class="room" style="display:none"></div>
+  </div>
 
   <div id="ui">
-    <button id="add-bed">Добавить кровать</button>
-    <button id="add-table">Добавить стол</button>
-    <button id="rotate-item">Повернуть выбранный</button>
-    <input id="seed-input" placeholder="Вставьте сид или нажмите «Сгенерировать" />
-    <button id="load-seed">Загрузить сид</button>
-    <button id="generate-seed">Сгенерировать сид</button>
-    <button id="copy-seed">Копировать сид</button>
+    <select id="item-select">
+      <optgroup label="\u041a\u0440\u043e\u0432\u0430\u0442\u0438">
+        <option value="bed">\u041a\u0440\u043e\u0432\u0430\u0442\u044c</option>
+      </optgroup>
+      <optgroup label="\u0421\u0442\u043e\u043b\u044b">
+        <option value="table">\u0421\u0442\u043e\u043b</option>
+      </optgroup>
+      <optgroup label="\u0421\u0442\u0443\u043b\u044c\u044f">
+        <option value="chair">\u0421\u0442\u0443\u043b</option>
+      </optgroup>
+      <optgroup label="\u0414\u0435\u043a\u043e\u0440">
+        <option value="plant">\u0420\u0430\u0441\u0442\u0435\u043d\u0438\u0435</option>
+      </optgroup>
+    </select>
+    <button id="add-item">\u0414\u043e\u0431\u0430\u0432\u0438\u0442\u044c</button>
+    <button id="rotate-item">\u041f\u043e\u0432\u0435\u0440\u043d\u0443\u0442\u044c \u0432\u044b\u0431\u0440\u0430\u043d\u043d\u044b\u0439</button>
+    <label>\u041f\u043e\u043b <input id="floor-color" type="color" value="#ffffff" /></label>
+    <label>\u0421\u0442\u0435\u043d\u044b <input id="wall-color" type="color" value="#e8e8e8" /></label>
+    <input id="seed-input" placeholder="\u0421\u0438\u0434 1" />
+    <button id="load-seed">\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044c</button>
+    <button id="generate-seed">\u0421\u0433\u0435\u043d\u0435\u0440\u0438\u0440\u043e\u0432\u0430\u0442\u044c</button>
+    <button id="copy-seed">\u041a\u043e\u043f\u0438\u0440\u043e\u0432\u0430\u0442\u044c</button>
     <textarea id="seed-output" readonly rows="2"></textarea>
+    <input id="seed-input-2" placeholder="\u0421\u0438\u0434 2" />
+    <button id="load-seed-2">\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044c 2</button>
+    <button id="compare-seeds">\u0421\u0440\u0430\u0432\u043d\u0438\u0442\u044c</button>
+    <div id="compare-output"></div>
   </div>
 
   <!-- PixiJS с CDN -->

--- a/main.js
+++ b/main.js
@@ -4,30 +4,50 @@ const TILE_SIZE = 64;      // размер клетки в пикселях
 const OFFSET_X = 100;      // отступ сцены от левого края холста
 const OFFSET_Y = 100;      // отступ сцены от верхнего края холста
 
-// Инициализация PixiJS
-const app = new PIXI.Application({
+// Инициализация двух сцен PixiJS
+const app1 = new PIXI.Application({
   backgroundColor: 0xdddddd,
   resizeTo: window,
   resolution: window.devicePixelRatio,
   roundPixels: true
 });
-document.getElementById('game-container').appendChild(app.view);
+const app2 = new PIXI.Application({
+  backgroundColor: 0xdddddd,
+  resizeTo: window,
+  resolution: window.devicePixelRatio,
+  roundPixels: true
+});
+document.getElementById('room1').appendChild(app1.view);
+document.getElementById('room2').appendChild(app2.view);
 
 // Контейнеры
-const gridContainer = new PIXI.Container();
-const furnitureContainer = new PIXI.Container();
-app.stage.addChild(gridContainer, furnitureContainer);
+const gridContainer1 = new PIXI.Container();
+const furnitureContainer1 = new PIXI.Container();
+app1.stage.addChild(gridContainer1, furnitureContainer1);
+
+const gridContainer2 = new PIXI.Container();
+const furnitureContainer2 = new PIXI.Container();
+app2.stage.addChild(gridContainer2, furnitureContainer2);
 
 // Состояние комнаты
 let roomState = {
   floorColor: 0xffffff,
+  wallColor: 0xe8e8e8,
   items: []  // { type, x, y, rotation, color }
+};
+
+let roomState2 = {
+  floorColor: 0xffffff,
+  wallColor: 0xe8e8e8,
+  items: []
 };
 
 // Определения мебели (пока прямоугольники)
 const furnitureDefs = {
   bed:   { w: 2, h: 1, color: 0xff4444 },
-  table: { w: 1, h: 1, color: 0x4444ff }
+  table: { w: 1, h: 1, color: 0x4444ff },
+  chair: { w: 1, h: 1, color: 0x22aa22 },
+  plant: { w: 1, h: 1, color: 0x228b22 }
 };
 
 function getItemSize(item) {
@@ -44,36 +64,36 @@ function clampItem(item) {
 }
 
 // Рисуем сетку с двумя стенами
-function drawGrid() {
-  gridContainer.removeChildren();
+function drawGrid(container, state) {
+  container.removeChildren();
   const g = new PIXI.Graphics();
 
   // пол
-  g.beginFill(roomState.floorColor);
+  g.beginFill(state.floorColor);
   g.drawRect(OFFSET_X, OFFSET_Y, GRID_SIZE * TILE_SIZE, GRID_SIZE * TILE_SIZE);
   g.endFill();
 
   // стены
-  g.beginFill(0xe8e8e8);
+  g.beginFill(state.wallColor);
   g.drawRect(OFFSET_X - TILE_SIZE, OFFSET_Y - GRID_SIZE * TILE_SIZE, GRID_SIZE * TILE_SIZE, GRID_SIZE * TILE_SIZE);
   g.endFill();
-  g.beginFill(0xf5f5f5);
+  g.beginFill(state.wallColor + 0x0f0f0f);
   g.drawRect(OFFSET_X - TILE_SIZE, OFFSET_Y - GRID_SIZE * TILE_SIZE, TILE_SIZE, GRID_SIZE * TILE_SIZE + TILE_SIZE);
   g.endFill();
 
   // линии сетки на полу
   g.lineStyle(1, 0x888888);
   for (let i = 0; i <= GRID_SIZE; i++) {
-    // вертикальные
     g.moveTo(OFFSET_X + i * TILE_SIZE, OFFSET_Y);
     g.lineTo(OFFSET_X + i * TILE_SIZE, OFFSET_Y + GRID_SIZE * TILE_SIZE);
-    // горизонтальные
     g.moveTo(OFFSET_X, OFFSET_Y + i * TILE_SIZE);
     g.lineTo(OFFSET_X + GRID_SIZE * TILE_SIZE, OFFSET_Y + i * TILE_SIZE);
   }
-  gridContainer.addChild(g);
+  container.addChild(g);
 }
-drawGrid();
+
+drawGrid(gridContainer1, roomState);
+drawGrid(gridContainer2, roomState2);
 
 // Добавить предмет в (0,0)
 function addFurniture(type) {
@@ -81,7 +101,7 @@ function addFurniture(type) {
   if (!def) return;
   const item = { type, x:0, y:0, rotation: 0, color: def.color };
   roomState.items.push(item);
-  drawFurniture();
+  drawFurniture(furnitureContainer1, roomState);
 }
 
 // Отрисовать всю мебель
@@ -114,7 +134,7 @@ function onPointerDown(e) {
     selectedItem = this.item;
     selectedItem.rotation = (selectedItem.rotation + 90) % 360;
     clampItem(selectedItem);
-    drawFurniture();
+    drawFurniture(furnitureContainer1, roomState);
     lastClick = 0;
     return;
   }
@@ -125,22 +145,22 @@ function onPointerDown(e) {
 
 function onPointerMove(e) {
   if (!dragging) return;
-  const pos = dragging.data.getLocalPosition(furnitureContainer);
+  const pos = dragging.data.getLocalPosition(furnitureContainer1);
   const size = getItemSize(dragging.item);
   dragging.item.x = Math.round((pos.x - dragging.offset.x - OFFSET_X) / TILE_SIZE);
   dragging.item.y = Math.round((OFFSET_Y + GRID_SIZE * TILE_SIZE - pos.y - dragging.offset.y - size.h * TILE_SIZE) / TILE_SIZE);
   clampItem(dragging.item);
-  drawFurniture();
+  drawFurniture(furnitureContainer1, roomState);
 }
 
 function onPointerUp() {
   dragging = null;
 }
 
-function drawFurniture() {
-  furnitureContainer.removeChildren();
-  roomState.items.forEach(item => {
-    furnitureContainer.addChild(createSprite(item));
+function drawFurniture(container, state) {
+  container.removeChildren();
+  state.items.forEach(item => {
+    container.addChild(createSprite(item));
   });
 }
 
@@ -155,22 +175,54 @@ function loadSeed(seed) {
   try {
     const json = LZString.decompressFromEncodedURIComponent(seed.trim());
     roomState = JSON.parse(json);
-    drawFurniture();
+    drawGrid(gridContainer1, roomState);
+    drawFurniture(furnitureContainer1, roomState);
     document.getElementById('seed-output').value = seed;
   } catch (e) {
     alert('Некорректный сид');
   }
 }
 
+function loadSeed2(seed) {
+  try {
+    const json = LZString.decompressFromEncodedURIComponent(seed.trim());
+    roomState2 = JSON.parse(json);
+    document.getElementById('room2').style.display = 'flex';
+    drawGrid(gridContainer2, roomState2);
+    drawFurniture(furnitureContainer2, roomState2);
+  } catch (e) {
+    alert('Некорректный сид');
+  }
+}
+
+function compareRooms(a, b) {
+  let matches = 0;
+  let total = Math.max(a.items.length, b.items.length) || 1;
+  a.items.forEach(itemA => {
+    const found = b.items.find(itemB => itemB.type === itemA.type && itemB.x === itemA.x && itemB.y === itemA.y && itemB.rotation === itemA.rotation && itemB.color === itemA.color);
+    if (found) matches++;
+  });
+  if (a.floorColor === b.floorColor) matches++;
+  if (a.wallColor === b.wallColor) matches++;
+  total += 2;
+  return Math.round((matches / total) * 100);
+}
+
 // UI-события
-document.getElementById('add-bed').onclick    = () => { addFurniture('bed'); };
-document.getElementById('add-table').onclick  = () => { addFurniture('table'); };
+document.getElementById('add-item').onclick = () => {
+  const type = document.getElementById('item-select').value;
+  addFurniture(type);
+};
 document.getElementById('generate-seed').onclick = () => {
   document.getElementById('seed-output').value = generateSeed();
 };
 document.getElementById('load-seed').onclick = () => {
   const seed = document.getElementById('seed-input').value;
   loadSeed(seed);
+};
+document.getElementById('load-seed-2').onclick = () => {
+  const seed = document.getElementById('seed-input-2').value;
+  loadSeed2(seed);
 };
 document.getElementById('copy-seed').onclick = async () => {
   const seed = document.getElementById('seed-output').value;
@@ -184,6 +236,26 @@ document.getElementById('rotate-item').onclick = () => {
   if (selectedItem) {
     selectedItem.rotation = (selectedItem.rotation + 90) % 360;
     clampItem(selectedItem);
-    drawFurniture();
+    drawFurniture(furnitureContainer1, roomState);
   }
+};
+document.getElementById('floor-color').oninput = e => {
+  roomState.floorColor = parseInt(e.target.value.replace('#','0x'));
+  drawGrid(gridContainer1, roomState);
+  drawFurniture(furnitureContainer1, roomState);
+};
+document.getElementById('wall-color').oninput = e => {
+  roomState.wallColor = parseInt(e.target.value.replace('#','0x'));
+  drawGrid(gridContainer1, roomState);
+  drawFurniture(furnitureContainer1, roomState);
+};
+
+document.getElementById('compare-seeds').onclick = () => {
+  const seed1 = generateSeed();
+  const seed2 = document.getElementById('seed-input-2').value.trim();
+  if (!seed2) return;
+  const json1 = JSON.parse(LZString.decompressFromEncodedURIComponent(seed1));
+  const json2 = JSON.parse(LZString.decompressFromEncodedURIComponent(seed2));
+  const score = compareRooms(json1, json2);
+  document.getElementById('compare-output').textContent = 'Совпадение: ' + score + '%';
 };

--- a/style.css
+++ b/style.css
@@ -9,9 +9,17 @@ body {
 #game-container {
   flex: 1 1 auto;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: center;
   background: #d0d0d0;
+}
+
+.room {
+  flex: 1 1 300px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 canvas {
@@ -36,6 +44,11 @@ canvas {
 
 #seed-output {
   flex: 1 1 100%;
+}
+
+#compare-output {
+  font-weight: bold;
+  padding: 4px 8px;
 }
 
 @media (min-width: 600px) {


### PR DESCRIPTION
## Summary
- add dual room containers for comparison
- support categories and color pickers in UI
- show side by side canvases via new CSS rules
- implement seed comparison and second room loading

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_685a75763f308332b02693df0885ed5b